### PR TITLE
If the test is OK, all steep was checked

### DIFF
--- a/PhpSecInfo/Test/Core/upload_tmp_dir.php
+++ b/PhpSecInfo/Test/Core/upload_tmp_dir.php
@@ -93,7 +93,7 @@ class PhpSecInfo_Test_Core_Upload_Tmp_Dir extends PhpSecInfo_Test_Core
 
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTRUN, 'en', 'Test not run -- currently disabled on Windows OSes');
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_OK, 'en', 'upload_tmp_dir is enabled, which is the
-						recommended setting. Make sure your upload_tmp_dir path is not world-readable');
+						recommended setting.');
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_WARN, 'en', 'unable to retrieve file permissions on upload_tmp_dir');
         $this->setMessageForResult(PHPSECINFO_TEST_RESULT_NOTICE, 'en', 'upload_tmp_dir is disabled, or is set to a
 						common world-writable directory.  This typically allows other users on this server


### PR DESCRIPTION
If the test is OK, all steep was checked

Change : upload_tmp_dir is enabled, which is the recommended setting. Make sure your upload_tmp_dir path is not world-readable
With : upload_tmp_dir is enabled, which is the recommended setting.