### PR TITLE
avoid deprecated array syntax

### DIFF
--- a/PhpSecInfo/Test/Test.php
+++ b/PhpSecInfo/Test/Test.php
@@ -380,7 +380,7 @@ class PhpSecInfo_Test
             return 0;
         }
 
-        $last = strtolower($val{strlen($val) - 1});
+        $last = strtolower($val[strlen($val) - 1]);
 
         if (is_string($last)) {
             $val = substr($val, 0, -1);


### PR DESCRIPTION
for PHP 7.4 compatibility
See matomo-org/matomo#14821 (comment) for more details.